### PR TITLE
CI: add arm64 Linux build

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -18,17 +18,18 @@ jobs:
       fail-fast: false
       matrix:
         env: [
-          {name: "Release",                       build_type: Release, arch: x86_64, upload: true,  cmake: ""},
-          {name: "Debug",                         build_type: Debug,   arch: x86_64, upload: true,  cmake: ""},
-          {name: "Debug D3D9 + Sokol + Asserts",  build_type: Debug,   arch: x86_64, upload: false, cmake: "-DOPTION_D3D9=ON -DOPTION_SOKOL=ON -DOPTION_DEBUG_ASSERT=ON"},
-          {name: "Release D3D9 + Sokol",          build_type: Release, arch: x86_64, upload: false, cmake: "-DOPTION_D3D9=ON -DOPTION_SOKOL=ON"},
-          {name: "Debug D3D9",                    build_type: Debug,   arch: x86_64, upload: false, cmake: "-DOPTION_D3D9=ON -DOPTION_SOKOL=OFF"},
-          {name: "Debug Sokol",                   build_type: Debug,   arch: x86_64, upload: false, cmake: "-DOPTION_D3D9=OFF -DOPTION_SOKOL=ON"},
-          {name: "Scripts Check",                 build_type: Release, arch: x86_64, upload: false, cmake: "-DOPTION_CHECK_SCRIPTS=ON "},
+          {name: "Release",                       build_type: Release, arch: x86_64, os: ubuntu-latest,    upload: true,  cmake: ""},
+          {name: "Release",                       build_type: Release, arch: arm64,  os: ubuntu-24.04-arm, upload: true,  cmake: ""},
+          {name: "Debug",                         build_type: Debug,   arch: x86_64, os: ubuntu-latest,    upload: true,  cmake: ""},
+          {name: "Debug D3D9 + Sokol + Asserts",  build_type: Debug,   arch: x86_64, os: ubuntu-latest,    upload: false, cmake: "-DOPTION_D3D9=ON -DOPTION_SOKOL=ON -DOPTION_DEBUG_ASSERT=ON"},
+          {name: "Release D3D9 + Sokol",          build_type: Release, arch: x86_64, os: ubuntu-latest,    upload: false, cmake: "-DOPTION_D3D9=ON -DOPTION_SOKOL=ON"},
+          {name: "Debug D3D9",                    build_type: Debug,   arch: x86_64, os: ubuntu-latest,    upload: false, cmake: "-DOPTION_D3D9=ON -DOPTION_SOKOL=OFF"},
+          {name: "Debug Sokol",                   build_type: Debug,   arch: x86_64, os: ubuntu-latest,    upload: false, cmake: "-DOPTION_D3D9=OFF -DOPTION_SOKOL=ON"},
+          {name: "Scripts Check",                 build_type: Release, arch: x86_64, os: ubuntu-latest,    upload: false, cmake: "-DOPTION_CHECK_SCRIPTS=ON "},
         ]
     name: ${{matrix.env.name}} ${{matrix.env.arch}}
     if: github.event.pull_request.draft != true
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.env.os}}
     container:
       image: "debian:buster"
     steps:

--- a/docker/linux/builder
+++ b/docker/linux/builder
@@ -12,7 +12,12 @@ BUILD_DIR=$WORK_DIR/build/docker-linux
 #Replace system SDL2 with ours
 if [[ -d "$LIBS_ROOT/sdl" ]]; then
   cp -va $LIBS_ROOT/sdl/include/* /usr/include/
-  cp -va $LIBS_ROOT/sdl/lib/* /usr/lib/x86_64-linux-gnu/
+  SYSTEM_ARCH=$(uname -m)
+  if [[ $SYSTEM_ARCH = "aarch64" ]]; then
+    cp -va $LIBS_ROOT/sdl/lib/* /usr/lib/aarch64-linux-gnu/
+  else
+    cp -va $LIBS_ROOT/sdl/lib/* /usr/lib/x86_64-linux-gnu/
+  fi
 fi
 
 #rm -rf $BUILD_DIR


### PR DESCRIPTION
I added only Release arm64 build. Tell me if you need Debug build or something else.
Here is screen of running Perimeter arm64 release build downloaded from github CI:
![Screenshot from 2025-01-26 09-57-01](https://github.com/user-attachments/assets/011faa12-3988-4138-a253-575b801ce05c)
